### PR TITLE
Changes necessary to run all unit tests in Postgresql

### DIFF
--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -277,9 +277,9 @@ module GHTorrent
           users.filter(:login => login).delete
           users.filter(:email => email).update(
               :login => login,
-              :company => added['company'],
-              :location => added['location'],
-              :created_at => added['created_at']
+              :company => added[:company],
+              :location => added[:location],
+              :created_at => added[:created_at]
           )
         end
       else

--- a/lib/ghtorrent/settings.rb
+++ b/lib/ghtorrent/settings.rb
@@ -58,7 +58,7 @@ module GHTorrent
         :user_agent => 'ghtorrent',
         :store_pull_request_commits => 'false',
 
-        :github_token => '',
+        :github_token => 'place your github token here',
 
         :attach_ip => '0.0.0.0',
 

--- a/lib/ghtorrent/settings.rb
+++ b/lib/ghtorrent/settings.rb
@@ -53,7 +53,7 @@ module GHTorrent
         :sql_url => 'sqlite://github.db',
         # :sql_url => 'mysql2://ghtorrent:ghtorrent@localhost/ghtorrent',
         :mirror_urlbase => 'https://api.github.com/',
-        :mirror_persister => 'noop',  #'noop',
+        :mirror_persister => 'noop',
         :mirror_history_pages_back => 10,
         :user_agent => 'ghtorrent',
         :store_pull_request_commits => 'false',
@@ -73,9 +73,7 @@ module GHTorrent
 
         :geolocation_service => 'osm',
         :geolocation_wait => '2',
-        :geolocation_bing_key => '',
-
-        :csv_file => 'lib/ghtorrent/csv_persist.csv'
+        :geolocation_bing_key => ''
     }
 
     def config(key, use_default = true)

--- a/lib/ghtorrent/settings.rb
+++ b/lib/ghtorrent/settings.rb
@@ -50,17 +50,15 @@ module GHTorrent
         :amqp_exchange => 'github',
         :amqp_prefetch  => 1,
 
-        # :sql_url => 'sqlite://github.db',
+        :sql_url => 'sqlite://github.db',
         # :sql_url => 'mysql2://ghtorrent:ghtorrent@localhost/ghtorrent',
-        :sql_url => "postgres://ght_admin:oh-Postgres!8@ght-db01.eastus.cloudapp.azure.com:5432/ghtorrent_test", 
-
         :mirror_urlbase => 'https://api.github.com/',
         :mirror_persister => 'noop',  #'noop',
         :mirror_history_pages_back => 10,
         :user_agent => 'ghtorrent',
         :store_pull_request_commits => 'false',
 
-        :github_token => '8978521a8430c9bdaf30f9e97b79a017ab5de584',
+        :github_token => '',
 
         :attach_ip => '0.0.0.0',
 

--- a/lib/ghtorrent/settings.rb
+++ b/lib/ghtorrent/settings.rb
@@ -51,15 +51,16 @@ module GHTorrent
         :amqp_prefetch  => 1,
 
         # :sql_url => 'sqlite://github.db',
-        :sql_url => 'mysql2://ghtorrent:ghtorrent@localhost/ghtorrent',
+        # :sql_url => 'mysql2://ghtorrent:ghtorrent@localhost/ghtorrent',
+        :sql_url => "postgres://ght_admin:oh-Postgres!8@ght-db01.eastus.cloudapp.azure.com:5432/ghtorrent_test", 
 
         :mirror_urlbase => 'https://api.github.com/',
-        :mirror_persister => 'noop',
+        :mirror_persister => 'noop',  #'noop',
         :mirror_history_pages_back => 10,
         :user_agent => 'ghtorrent',
         :store_pull_request_commits => 'false',
 
-        :github_token => 'place your github token here',
+        :github_token => '8978521a8430c9bdaf30f9e97b79a017ab5de584',
 
         :attach_ip => '0.0.0.0',
 
@@ -74,7 +75,9 @@ module GHTorrent
 
         :geolocation_service => 'osm',
         :geolocation_wait => '2',
-        :geolocation_bing_key => ''
+        :geolocation_bing_key => '',
+
+        :csv_file => 'lib/ghtorrent/csv_persist.csv'
     }
 
     def config(key, use_default = true)

--- a/test/factories/commit.rb
+++ b/test/factories/commit.rb
@@ -34,6 +34,7 @@ FactoryGirl.define do
 
         attributes = apply_overrides_and_transients(:commit, evaluator)
         if commit.db_obj
+          attributes = attributes.except(:id)
           commit.id = commit.db_obj[:commits].insert(attributes)
         end
       end

--- a/test/factories/commit_comments.rb
+++ b/test/factories/commit_comments.rb
@@ -24,6 +24,7 @@ FactoryGirl.define do
     after(:create) do | commit_comment, evaluator |
       attributes = apply_overrides_and_transients(:commit_comment, evaluator)
       if commit_comment.db_obj
+        attributes = attributes.except(:id)
         commit_comment.id = commit_comment.db_obj[:commit_comments].insert(attributes)
       end
     end

--- a/test/factories/follower.rb
+++ b/test/factories/follower.rb
@@ -14,6 +14,7 @@ FactoryGirl.define do
           attributes = apply_overrides_and_transients(:follower, evaluator)
 
           if follower.db_obj
+            attributes = attributes.except(:id)
             follower.id = follower.db_obj[:followers].insert(attributes)
           end
         end

--- a/test/factories/issue.rb
+++ b/test/factories/issue.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
       repo_id nil
       reporter_id nil
       assignee_id nil
-      pull_request 0
+      pull_request false
       pull_request_id nil
       created_at { Time.now.utc.strftime('%F %T') }
       issue_id {Faker::Number.number(2) }

--- a/test/factories/issue.rb
+++ b/test/factories/issue.rb
@@ -48,6 +48,7 @@ FactoryGirl.define do
 
           attributes = apply_overrides_and_transients(:issue, evaluator)
           if issue.db_obj
+            attributes = attributes.except(:id)
             issue.id = issue.db_obj[:issues].insert(attributes)
           end
         end

--- a/test/factories/issue_comment.rb
+++ b/test/factories/issue_comment.rb
@@ -33,6 +33,7 @@ FactoryGirl.define do
         attributes = apply_overrides_and_transients(:issue_comment, evaluator)
 
         if issue_comment.db_obj
+          attributes = attributes.except(:id)
           issue_comment.db_obj[:issue_comments].insert(attributes)
         end
       end

--- a/test/factories/issue_event.rb
+++ b/test/factories/issue_event.rb
@@ -42,6 +42,7 @@ FactoryGirl.define do
 
           attributes = apply_overrides_and_transients(:issue_event, evaluator)
           if issue_event.db_obj
+            attributes = attributes.except(:id)
             issue_event.db_obj[:issue_events].insert(attributes)
           end
         end

--- a/test/factories/issue_label.rb
+++ b/test/factories/issue_label.rb
@@ -31,6 +31,7 @@ FactoryGirl.define do
         attributes = apply_overrides_and_transients(:issue_label, evaluator)
 
         if issue_label.db_obj
+          attributes = attributes.except(:id)
           issue_label.db_obj[:issue_labels].insert(attributes)
         end
       end

--- a/test/factories/project.rb
+++ b/test/factories/project.rb
@@ -47,6 +47,7 @@ FactoryGirl.define do
 
         attributes = apply_overrides_and_transients(:project, evaluator)
         if project.db_obj
+          attributes = attributes.except(:id)
           project.id = project.db_obj[:projects].insert(attributes)
         end
       end

--- a/test/factories/pull_request.rb
+++ b/test/factories/pull_request.rb
@@ -54,6 +54,7 @@ FactoryGirl.define do
           attributes = apply_overrides_and_transients(:pull_request, evaluator)
 
           if pull_request.db_obj
+            attributes = attributes.except(:id)
             pull_request.id = pull_request.db_obj[:pull_requests].insert(attributes)
           end
         end

--- a/test/factories/pull_request_comment.rb
+++ b/test/factories/pull_request_comment.rb
@@ -46,6 +46,7 @@ FactoryGirl.define do
           attributes = apply_overrides_and_transients(:pull_request_comment, evaluator)
 
           if pull_request_comment.db_obj
+            attributes = attributes.except(:id)
             pull_request_comment.db_obj[:pull_request_comments].insert(attributes)
           end
         end

--- a/test/factories/pull_request_commit.rb
+++ b/test/factories/pull_request_commit.rb
@@ -40,6 +40,7 @@ FactoryGirl.define do
           attributes = apply_overrides_and_transients(:pull_request_commit, evaluator)
 
           if pull_request_commit.db_obj
+            attributes = attributes.except(:id)
             pull_request_commit.db_obj[:pull_request_commits].insert(attributes)
           end
         end

--- a/test/factories/repo_label.rb
+++ b/test/factories/repo_label.rb
@@ -32,6 +32,7 @@ FactoryGirl.define do
         attributes = apply_overrides_and_transients(:repo_label, evaluator)
 
         if repo_label.db_obj
+          attributes = attributes.except(:id)
           repo_label.id = repo_label.db_obj[:repo_labels].insert(attributes)
         end
       end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -38,6 +38,7 @@ FactoryGirl.define do
         attributes = apply_overrides_and_transients(:user, evaluator)
 
         if user.db_obj
+          attributes = attributes.except(:id)
           user.id = user.db_obj[:users].insert(attributes)
         end
       end

--- a/test/factories/watcher.rb
+++ b/test/factories/watcher.rb
@@ -14,6 +14,7 @@ FactoryGirl.define do
           attributes = apply_overrides_and_transients(:watcher, evaluator)
 
           if watcher.db_obj
+            attributes = attributes.except(:id)
             watcher.id = watcher.db_obj[:watchers].insert(attributes)
           end
         end


### PR DESCRIPTION
Needed to remove the primary key field in the table factories.  MySql is very forgiving regarding the primary key as part of the sql insert statement.  Postgresql does not like it.  

Found an issue with the current ghttorrent code that the hash returned from a find would not handle the string key and needed a symbol instead.  

Tested in both mysql and Postgresql with all but one test passing (vcr test).

I will squash and merge my commits before closing this pull request