### PR TITLE
Fix log directory creation and travis build failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ DEPENDENCIES
   minitest-around
   mocha
   mysql2
+  rake
   simplecov
   simplecov-rcov
   sqlite3 (= 1.3.13)
@@ -90,4 +91,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/ghtorrent.gemspec
+++ b/ghtorrent.gemspec
@@ -1,4 +1,3 @@
-require 'rake'
 require File.expand_path('../lib/version', __FILE__)
 
 Gem::Specification.new do |s|
@@ -18,10 +17,10 @@ Gem::Specification.new do |s|
                      'ght-retrieve-repo', 'ght-retrieve-user',
                      'ght-retrieve-repos', 'ght-retrieve-users',
                      'ght-mass-harvester']
-  s.files         = FileList['lib/**/*.rb',
+  s.files         = Dir.glob(['lib/**/*.rb',
                              'bin/*',
                              '[A-Z]*',
-                             'lib/ghtorrent/country_codes.txt'].to_a
+                             'lib/ghtorrent/country_codes.txt'])
   s.required_ruby_version = '~> 2.0'
 
   s.add_runtime_dependency 'mongo', '~> 2.4', '>= 2.4.3'
@@ -43,6 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'minitest-around'
+  s.add_development_dependency 'rake'
   begin
     require 'changelog'
     s.post_install_message = CHANGELOG.new.version_changes

--- a/test/unit/logging_test.rb
+++ b/test/unit/logging_test.rb
@@ -51,6 +51,7 @@ describe 'Logging' do
   end
 
   it 'should log to a file' do
+    FileUtils::mkdir_p('test/log')
     TestLogging::DEFAULTS[:logging_file] = 'test/log/test.log'
     log.config(:logging_file).stubs(:casecmp).returns(false)
     log.error(msg)


### PR DESCRIPTION
`require 'rake'` in `ghtorrent.gemspec` breaks `bundle install` in travis on first run i.e. when there are no gems installed in system.
[Failing travis Build](https://travis-ci.org/gousiosg/github-mirror/builds/407758889?utm_source=github_status&utm_medium=notification)