### PR TITLE
OTWO-5262 - Verify new elements in RMQ event stream in Azure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ platforms :jruby do
   gem 'jdbc-mysql'
 end
 
-gem 'mysql2'
+gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
     mongo (2.5.1)
       bson (>= 4.3.0, < 5.0.0)
     multi_json (1.13.1)
-    mysql2 (0.5.1)
+    pg (1.0.0)
     public_suffix (3.0.2)
     rake (12.3.1)
     safe_yaml (1.0.4)
@@ -82,7 +82,7 @@ DEPENDENCIES
   minitest (~> 4.7.3)
   minitest-around
   mocha
-  mysql2
+  pg
   simplecov
   simplecov-rcov
   sqlite3 (= 1.3.13)
@@ -90,4 +90,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/bin/ght-mass-harvester
+++ b/bin/ght-mass-harvester
@@ -59,6 +59,10 @@ all GitHub users or repositories and add the non-existing ones to the database.
     @ght
   end
 
+  def db
+    ght.db
+  end
+
   def go
     @last_load_file = "mass-harvester.lasturl"
 

--- a/bin/ght-mass-harvester
+++ b/bin/ght-mass-harvester
@@ -58,7 +58,9 @@ all GitHub users or repositories and add the non-existing ones to the database.
     @ght ||= TransactedGHTorrent.new(@settings)
     @ght
   end
-
+  def db
+    ght.db
+  end
   def go
     @last_load_file = "mass-harvester.lasturl"
 

--- a/fixtures/vcr_cassettes/github_etags.yml
+++ b/fixtures/vcr_cassettes/github_etags.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/users/linus/followers?page=43&per_page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ghtorrent
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 18 Jun 2018 06:08:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1529304526'
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Vary:
+      - Accept
+      Etag:
+      - W/"05d357bde1fe90eb9bd50bd7737e7d7f"
+      X-Github-Media-Type:
+      - github.v3
+      Link:
+      - <https://api.github.com/user/105278/followers?page=42&per_page=2>; rel="prev",
+        <https://api.github.com/user/105278/followers?page=1&per_page=2>; rel="first"
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Runtime-Rack:
+      - '0.027791'
+      X-Github-Request-Id:
+      - 97E0:6144:458CE33:968B9D5:5B274C45
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"hiroki-tkg","id":5345000,"node_id":"MDQ6VXNlcjUzNDUwMDA=","avatar_url":"https://avatars2.githubusercontent.com/u/5345000?v=4","gravatar_id":"","url":"https://api.github.com/users/hiroki-tkg","html_url":"https://github.com/hiroki-tkg","followers_url":"https://api.github.com/users/hiroki-tkg/followers","following_url":"https://api.github.com/users/hiroki-tkg/following{/other_user}","gists_url":"https://api.github.com/users/hiroki-tkg/gists{/gist_id}","starred_url":"https://api.github.com/users/hiroki-tkg/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/hiroki-tkg/subscriptions","organizations_url":"https://api.github.com/users/hiroki-tkg/orgs","repos_url":"https://api.github.com/users/hiroki-tkg/repos","events_url":"https://api.github.com/users/hiroki-tkg/events{/privacy}","received_events_url":"https://api.github.com/users/hiroki-tkg/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Mon, 18 Jun 2018 06:08:06 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/github_etags_front_loaded.yml
+++ b/fixtures/vcr_cassettes/github_etags_front_loaded.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/blackducksoftware/ohcount/events?page=1&per_page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ghtorrent
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 18 Jun 2018 06:13:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '46'
+      X-Ratelimit-Reset:
+      - '1529304526'
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Vary:
+      - Accept
+      Etag:
+      - W/"994a7ec716e09c6e54191b603e88d788"
+      Last-Modified:
+      - Sun, 17 Jun 2018 06:35:29 GMT
+      X-Poll-Interval:
+      - '60'
+      X-Github-Media-Type:
+      - github.v3
+      Link:
+      - <https://api.github.com/repositories/1029520/events?page=2&per_page=2>; rel="next",
+        <https://api.github.com/repositories/1029520/events?page=22&per_page=2>; rel="last"
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Runtime-Rack:
+      - '0.075215'
+      X-Github-Request-Id:
+      - 97E8:6144:4599D18:96A83A4:5B274DA6
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":"7835480810","type":"WatchEvent","actor":{"id":227771,"login":"scjung","display_login":"scjung","gravatar_id":"","url":"https://api.github.com/users/scjung","avatar_url":"https://avatars.githubusercontent.com/u/227771?"},"repo":{"id":1029520,"name":"blackducksoftware/ohcount","url":"https://api.github.com/repos/blackducksoftware/ohcount"},"payload":{"action":"started"},"public":true,"created_at":"2018-06-17T06:35:29Z","org":{"id":431461,"login":"blackducksoftware","gravatar_id":"","url":"https://api.github.com/orgs/blackducksoftware","avatar_url":"https://avatars.githubusercontent.com/u/431461?"}},{"id":"7815990636","type":"WatchEvent","actor":{"id":17812226,"login":"43h","display_login":"43h","gravatar_id":"","url":"https://api.github.com/users/43h","avatar_url":"https://avatars.githubusercontent.com/u/17812226?"},"repo":{"id":1029520,"name":"blackducksoftware/ohcount","url":"https://api.github.com/repos/blackducksoftware/ohcount"},"payload":{"action":"started"},"public":true,"created_at":"2018-06-13T01:46:04Z","org":{"id":431461,"login":"blackducksoftware","gravatar_id":"","url":"https://api.github.com/orgs/blackducksoftware","avatar_url":"https://avatars.githubusercontent.com/u/431461?"}}]'
+    http_version: 
+  recorded_at: Mon, 18 Jun 2018 06:14:00 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/github_etags_front_loaded_not_modified.yml
+++ b/fixtures/vcr_cassettes/github_etags_front_loaded_not_modified.yml
@@ -1,0 +1,267 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/blackducksoftware/ohcount/events?page=1&per_page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ghtorrent
+      Accept:
+      - application/json
+      If-None-Match:
+      - W/"c483d6f23e912a62cb1ae11316662174"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 304
+      message: Not Modified
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sun, 15 Jul 2018 23:03:26 GMT
+      Content-Type:
+      - application/octet-stream
+      Status:
+      - 304 Not Modified
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '57'
+      X-Ratelimit-Reset:
+      - '1531698971'
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Vary:
+      - Accept
+      Etag:
+      - '"c483d6f23e912a62cb1ae11316662174"'
+      Last-Modified:
+      - Sat, 23 Jun 2018 13:16:21 GMT
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Runtime-Rack:
+      - '0.064837'
+      X-Github-Request-Id:
+      - CFB4:12A4:6908F77:C412E3F:5B4BD2BD
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 15 Jul 2018 23:03:26 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/blackducksoftware/ohcount/events?page=1&per_page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ghtorrent
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sun, 15 Jul 2018 23:03:28 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '56'
+      X-Ratelimit-Reset:
+      - '1531698971'
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Vary:
+      - Accept
+      Etag:
+      - W/"c483d6f23e912a62cb1ae11316662174"
+      Last-Modified:
+      - Sat, 23 Jun 2018 13:16:21 GMT
+      X-Poll-Interval:
+      - '60'
+      X-Github-Media-Type:
+      - github.v3
+      Link:
+      - <https://api.github.com/repositories/1029520/events?page=2&per_page=2>; rel="next",
+        <https://api.github.com/repositories/1029520/events?page=21&per_page=2>; rel="last"
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Runtime-Rack:
+      - '0.062763'
+      X-Github-Request-Id:
+      - CFB5:12A4:690906D:C413007:5B4BD2BF
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        W3siaWQiOiI3ODY3Nzc3MTA4IiwidHlwZSI6Iklzc3VlQ29tbWVudEV2ZW50
+        IiwiYWN0b3IiOnsiaWQiOjczMzMyNiwibG9naW4iOiJzeWx2ZXN0cmUiLCJk
+        aXNwbGF5X2xvZ2luIjoic3lsdmVzdHJlIiwiZ3JhdmF0YXJfaWQiOiIiLCJ1
+        cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3N5bHZlc3RyZSIs
+        ImF2YXRhcl91cmwiOiJodHRwczovL2F2YXRhcnMuZ2l0aHVidXNlcmNvbnRl
+        bnQuY29tL3UvNzMzMzI2PyJ9LCJyZXBvIjp7ImlkIjoxMDI5NTIwLCJuYW1l
+        IjoiYmxhY2tkdWNrc29mdHdhcmUvb2hjb3VudCIsInVybCI6Imh0dHBzOi8v
+        YXBpLmdpdGh1Yi5jb20vcmVwb3MvYmxhY2tkdWNrc29mdHdhcmUvb2hjb3Vu
+        dCJ9LCJwYXlsb2FkIjp7ImFjdGlvbiI6ImNyZWF0ZWQiLCJpc3N1ZSI6eyJ1
+        cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2JsYWNrZHVja3Nv
+        ZnR3YXJlL29oY291bnQvaXNzdWVzLzU0IiwicmVwb3NpdG9yeV91cmwiOiJo
+        dHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2JsYWNrZHVja3NvZnR3YXJl
+        L29oY291bnQiLCJsYWJlbHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNv
+        bS9yZXBvcy9ibGFja2R1Y2tzb2Z0d2FyZS9vaGNvdW50L2lzc3Vlcy81NC9s
+        YWJlbHN7L25hbWV9IiwiY29tbWVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0
+        aHViLmNvbS9yZXBvcy9ibGFja2R1Y2tzb2Z0d2FyZS9vaGNvdW50L2lzc3Vl
+        cy81NC9jb21tZW50cyIsImV2ZW50c191cmwiOiJodHRwczovL2FwaS5naXRo
+        dWIuY29tL3JlcG9zL2JsYWNrZHVja3NvZnR3YXJlL29oY291bnQvaXNzdWVz
+        LzU0L2V2ZW50cyIsImh0bWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2Js
+        YWNrZHVja3NvZnR3YXJlL29oY291bnQvcHVsbC81NCIsImlkIjoyNTU0MjY2
+        ODUsIm5vZGVfaWQiOiJNREV4T2xCMWJHeFNaWEYxWlhOME1UTTVORE0wTmpB
+        MyIsIm51bWJlciI6NTQsInRpdGxlIjoiU29tZSBmaXhlcyBmb3IgYnVpbGRp
+        bmcgb24gRmVkb3JhIiwidXNlciI6eyJsb2dpbiI6ImJsdWVkcmVhbWVyIiwi
+        aWQiOjc1MzYxMCwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjMU16WXhNQT09Iiwi
+        YXZhdGFyX3VybCI6Imh0dHBzOi8vYXZhdGFyczEuZ2l0aHVidXNlcmNvbnRl
+        bnQuY29tL3UvNzUzNjEwP3Y9NCIsImdyYXZhdGFyX2lkIjoiIiwidXJsIjoi
+        aHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ibHVlZHJlYW1lciIsImh0
+        bWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2JsdWVkcmVhbWVyIiwiZm9s
+        bG93ZXJzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvYmx1
+        ZWRyZWFtZXIvZm9sbG93ZXJzIiwiZm9sbG93aW5nX3VybCI6Imh0dHBzOi8v
+        YXBpLmdpdGh1Yi5jb20vdXNlcnMvYmx1ZWRyZWFtZXIvZm9sbG93aW5ney9v
+        dGhlcl91c2VyfSIsImdpc3RzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j
+        b20vdXNlcnMvYmx1ZWRyZWFtZXIvZ2lzdHN7L2dpc3RfaWR9Iiwic3RhcnJl
+        ZF91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2JsdWVkcmVh
+        bWVyL3N0YXJyZWR7L293bmVyfXsvcmVwb30iLCJzdWJzY3JpcHRpb25zX3Vy
+        bCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvYmx1ZWRyZWFtZXIv
+        c3Vic2NyaXB0aW9ucyIsIm9yZ2FuaXphdGlvbnNfdXJsIjoiaHR0cHM6Ly9h
+        cGkuZ2l0aHViLmNvbS91c2Vycy9ibHVlZHJlYW1lci9vcmdzIiwicmVwb3Nf
+        dXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ibHVlZHJlYW1l
+        ci9yZXBvcyIsImV2ZW50c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t
+        L3VzZXJzL2JsdWVkcmVhbWVyL2V2ZW50c3svcHJpdmFjeX0iLCJyZWNlaXZl
+        ZF9ldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9i
+        bHVlZHJlYW1lci9yZWNlaXZlZF9ldmVudHMiLCJ0eXBlIjoiVXNlciIsInNp
+        dGVfYWRtaW4iOmZhbHNlfSwibGFiZWxzIjpbXSwic3RhdGUiOiJvcGVuIiwi
+        bG9ja2VkIjpmYWxzZSwiYXNzaWduZWUiOm51bGwsImFzc2lnbmVlcyI6W10s
+        Im1pbGVzdG9uZSI6bnVsbCwiY29tbWVudHMiOjcsImNyZWF0ZWRfYXQiOiIy
+        MDE3LTA5LTA1VDIyOjI1OjM0WiIsInVwZGF0ZWRfYXQiOiIyMDE4LTA2LTIz
+        VDEzOjE2OjIxWiIsImNsb3NlZF9hdCI6bnVsbCwiYXV0aG9yX2Fzc29jaWF0
+        aW9uIjoiTk9ORSIsInB1bGxfcmVxdWVzdCI6eyJ1cmwiOiJodHRwczovL2Fw
+        aS5naXRodWIuY29tL3JlcG9zL2JsYWNrZHVja3NvZnR3YXJlL29oY291bnQv
+        cHVsbHMvNTQiLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9ibGFj
+        a2R1Y2tzb2Z0d2FyZS9vaGNvdW50L3B1bGwvNTQiLCJkaWZmX3VybCI6Imh0
+        dHBzOi8vZ2l0aHViLmNvbS9ibGFja2R1Y2tzb2Z0d2FyZS9vaGNvdW50L3B1
+        bGwvNTQuZGlmZiIsInBhdGNoX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9i
+        bGFja2R1Y2tzb2Z0d2FyZS9vaGNvdW50L3B1bGwvNTQucGF0Y2gifSwiYm9k
+        eSI6IkZpeCBlcnJvciBjYXVzZWQgZnJvbSBGZWRvcmEgL2V0Yy9pc3N1ZSBm
+        aWxlIGNvbnRhaW5pbmcgYFxcU2AgZXNjYXBlIHNlcXVlbmNlXHJcbmBgYFxy
+        XG51bmhhbmRsZWQgL2V0Yy9pc3N1ZSByZXN1bHQ6IFxcc1xyXG5CdWlsZGlu
+        ZyBPaGNvdW50XHJcblxyXG5gYGBcclxuRml4IGNvbXBpbGUgZXJyb3Igd2l0
+        aCBkaWZmZXJlbnQgZnVuY3Rpb24gc2lnbmF0dXJlc1xyXG5cclxubGFuZ3Vh
+        Z2VzLmdwZXJmOjY2OjE6IGVycm9yOiBjb25mbGljdGluZyB0eXBlcyBmb3Ig
+        4oCYb2hjb3VudF9oYXNoX2xhbmd1YWdlX2Zyb21fbmFtZeKAmVxyXG5JbiBm
+        aWxlIGluY2x1ZGVkIGZyb20gbGFuZ3VhZ2VzLmdwZXJmOjI6MDpcclxuc3Jj
+        L2hhc2gvLi4vbGFuZ3VhZ2VzLmg6MTIyOjIxOiBub3RlOiBwcmV2aW91cyBk
+        ZWNsYXJhdGlvbiBvZiDigJhvaGNvdW50X2hhc2hfbGFuZ3VhZ2VfZnJvbV9u
+        YW1l4oCZIHdhcyBoZXJlXHJcbiBzdHJ1Y3QgTGFuZ3VhZ2VNYXAgKm9oY291
+        bnRfaGFzaF9sYW5ndWFnZV9mcm9tX25hbWUocmVnaXN0ZXIgY29uc3QgY2hh
+        ciAqc3RyLCByZWdpc3RlciB1bnNpZ25lZCBpbnQgbGVuKTtcclxuICAgICAg
+        ICAgICAgICAgICAgICAgXn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+
+        flxyXG4ifSwiY29tbWVudCI6eyJ1cmwiOiJodHRwczovL2FwaS5naXRodWIu
+        Y29tL3JlcG9zL2JsYWNrZHVja3NvZnR3YXJlL29oY291bnQvaXNzdWVzL2Nv
+        bW1lbnRzLzM5OTY3Nzg0NSIsImh0bWxfdXJsIjoiaHR0cHM6Ly9naXRodWIu
+        Y29tL2JsYWNrZHVja3NvZnR3YXJlL29oY291bnQvcHVsbC81NCNpc3N1ZWNv
+        bW1lbnQtMzk5Njc3ODQ1IiwiaXNzdWVfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0
+        aHViLmNvbS9yZXBvcy9ibGFja2R1Y2tzb2Z0d2FyZS9vaGNvdW50L2lzc3Vl
+        cy81NCIsImlkIjozOTk2Nzc4NDUsIm5vZGVfaWQiOiJNREV5T2tsemMzVmxR
+        Mjl0YldWdWRETTVPVFkzTnpnME5RPT0iLCJ1c2VyIjp7ImxvZ2luIjoic3ls
+        dmVzdHJlIiwiaWQiOjczMzMyNiwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjek16
+        TXlOZz09IiwiYXZhdGFyX3VybCI6Imh0dHBzOi8vYXZhdGFyczIuZ2l0aHVi
+        dXNlcmNvbnRlbnQuY29tL3UvNzMzMzI2P3Y9NCIsImdyYXZhdGFyX2lkIjoi
+        IiwidXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9zeWx2ZXN0
+        cmUiLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9zeWx2ZXN0cmUi
+        LCJmb2xsb3dlcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vy
+        cy9zeWx2ZXN0cmUvZm9sbG93ZXJzIiwiZm9sbG93aW5nX3VybCI6Imh0dHBz
+        Oi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvc3lsdmVzdHJlL2ZvbGxvd2luZ3sv
+        b3RoZXJfdXNlcn0iLCJnaXN0c191cmwiOiJodHRwczovL2FwaS5naXRodWIu
+        Y29tL3VzZXJzL3N5bHZlc3RyZS9naXN0c3svZ2lzdF9pZH0iLCJzdGFycmVk
+        X3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvc3lsdmVzdHJl
+        L3N0YXJyZWR7L293bmVyfXsvcmVwb30iLCJzdWJzY3JpcHRpb25zX3VybCI6
+        Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvc3lsdmVzdHJlL3N1YnNj
+        cmlwdGlvbnMiLCJvcmdhbml6YXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdp
+        dGh1Yi5jb20vdXNlcnMvc3lsdmVzdHJlL29yZ3MiLCJyZXBvc191cmwiOiJo
+        dHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3N5bHZlc3RyZS9yZXBvcyIs
+        ImV2ZW50c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3N5
+        bHZlc3RyZS9ldmVudHN7L3ByaXZhY3l9IiwicmVjZWl2ZWRfZXZlbnRzX3Vy
+        bCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvc3lsdmVzdHJlL3Jl
+        Y2VpdmVkX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwic2l0ZV9hZG1pbiI6ZmFs
+        c2V9LCJjcmVhdGVkX2F0IjoiMjAxOC0wNi0yM1QxMzoxNjoyMVoiLCJ1cGRh
+        dGVkX2F0IjoiMjAxOC0wNi0yM1QxMzoxNjoyMVoiLCJhdXRob3JfYXNzb2Np
+        YXRpb24iOiJOT05FIiwiYm9keSI6IkBtc2s5OTkgV291bGQgYmUgZ3JlYXQg
+        aWYgeW91IGNvdWxkIG1lcmdlIHRoYXQgaW4gdGhlIG5leHQgcmVsZWFzZSEg
+        VGhhbmtzISJ9fSwicHVibGljIjp0cnVlLCJjcmVhdGVkX2F0IjoiMjAxOC0w
+        Ni0yM1QxMzoxNjoyMVoiLCJvcmciOnsiaWQiOjQzMTQ2MSwibG9naW4iOiJi
+        bGFja2R1Y2tzb2Z0d2FyZSIsImdyYXZhdGFyX2lkIjoiIiwidXJsIjoiaHR0
+        cHM6Ly9hcGkuZ2l0aHViLmNvbS9vcmdzL2JsYWNrZHVja3NvZnR3YXJlIiwi
+        YXZhdGFyX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVu
+        dC5jb20vdS80MzE0NjE/In19LHsiaWQiOiI3ODQ0Mjg0Nzk0IiwidHlwZSI6
+        IldhdGNoRXZlbnQiLCJhY3RvciI6eyJpZCI6MTYzNzcxMSwibG9naW4iOiJu
+        b3RhbGV4IiwiZGlzcGxheV9sb2dpbiI6Im5vdGFsZXgiLCJncmF2YXRhcl9p
+        ZCI6IiIsInVybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvbm90
+        YWxleCIsImF2YXRhcl91cmwiOiJodHRwczovL2F2YXRhcnMuZ2l0aHVidXNl
+        cmNvbnRlbnQuY29tL3UvMTYzNzcxMT8ifSwicmVwbyI6eyJpZCI6MTAyOTUy
+        MCwibmFtZSI6ImJsYWNrZHVja3NvZnR3YXJlL29oY291bnQiLCJ1cmwiOiJo
+        dHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2JsYWNrZHVja3NvZnR3YXJl
+        L29oY291bnQifSwicGF5bG9hZCI6eyJhY3Rpb24iOiJzdGFydGVkIn0sInB1
+        YmxpYyI6dHJ1ZSwiY3JlYXRlZF9hdCI6IjIwMTgtMDYtMTlUMDk6MTA6NTda
+        Iiwib3JnIjp7ImlkIjo0MzE0NjEsImxvZ2luIjoiYmxhY2tkdWNrc29mdHdh
+        cmUiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0dHBzOi8vYXBpLmdpdGh1
+        Yi5jb20vb3Jncy9ibGFja2R1Y2tzb2Z0d2FyZSIsImF2YXRhcl91cmwiOiJo
+        dHRwczovL2F2YXRhcnMuZ2l0aHVidXNlcmNvbnRlbnQuY29tL3UvNDMxNDYx
+        PyJ9fV0=
+    http_version: 
+  recorded_at: Sun, 15 Jul 2018 23:03:29 GMT
+recorded_with: VCR 4.0.0

--- a/fixtures/vcr_cassettes/github_etags_not_modified.yml
+++ b/fixtures/vcr_cassettes/github_etags_not_modified.yml
@@ -1,0 +1,140 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/users/linus/followers?page=44&per_page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ghtorrent
+      Accept:
+      - application/json
+      If-None-Match:
+      - W/"7e96712c73e285b2d348146921ccc000"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 304
+      message: Not Modified
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sun, 15 Jul 2018 23:15:45 GMT
+      Content-Type:
+      - application/octet-stream
+      Status:
+      - 304 Not Modified
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '47'
+      X-Ratelimit-Reset:
+      - '1531698971'
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Vary:
+      - Accept
+      Etag:
+      - '"7e96712c73e285b2d348146921ccc000"'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Runtime-Rack:
+      - '0.027950'
+      X-Github-Request-Id:
+      - CFFE:12A4:691AAA8:C433E2A:5B4BD5A0
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 15 Jul 2018 23:15:45 GMT
+- request:
+    method: get
+    uri: https://api.github.com/users/linus/followers?per_page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ghtorrent
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sun, 15 Jul 2018 23:15:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '46'
+      X-Ratelimit-Reset:
+      - '1531698971'
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Vary:
+      - Accept
+      Etag:
+      - W/"014f26d1b4b9c926514b93e2cb287f1a"
+      X-Github-Media-Type:
+      - github.v3
+      Link:
+      - <https://api.github.com/user/105278/followers?per_page=2&page=2>; rel="next",
+        <https://api.github.com/user/105278/followers?per_page=2&page=44>; rel="last"
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Runtime-Rack:
+      - '0.036079'
+      X-Github-Request-Id:
+      - D000:12A2:2BADFA8:654DAE1:5B4BD5A2
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"aredridel","id":2876,"node_id":"MDQ6VXNlcjI4NzY=","avatar_url":"https://avatars3.githubusercontent.com/u/2876?v=4","gravatar_id":"","url":"https://api.github.com/users/aredridel","html_url":"https://github.com/aredridel","followers_url":"https://api.github.com/users/aredridel/followers","following_url":"https://api.github.com/users/aredridel/following{/other_user}","gists_url":"https://api.github.com/users/aredridel/gists{/gist_id}","starred_url":"https://api.github.com/users/aredridel/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/aredridel/subscriptions","organizations_url":"https://api.github.com/users/aredridel/orgs","repos_url":"https://api.github.com/users/aredridel/repos","events_url":"https://api.github.com/users/aredridel/events{/privacy}","received_events_url":"https://api.github.com/users/aredridel/received_events","type":"User","site_admin":false},{"login":"skanev","id":10382,"node_id":"MDQ6VXNlcjEwMzgy","avatar_url":"https://avatars1.githubusercontent.com/u/10382?v=4","gravatar_id":"","url":"https://api.github.com/users/skanev","html_url":"https://github.com/skanev","followers_url":"https://api.github.com/users/skanev/followers","following_url":"https://api.github.com/users/skanev/following{/other_user}","gists_url":"https://api.github.com/users/skanev/gists{/gist_id}","starred_url":"https://api.github.com/users/skanev/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/skanev/subscriptions","organizations_url":"https://api.github.com/users/skanev/orgs","repos_url":"https://api.github.com/users/skanev/repos","events_url":"https://api.github.com/users/skanev/events{/privacy}","received_events_url":"https://api.github.com/users/skanev/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Sun, 15 Jul 2018 23:15:47 GMT
+recorded_with: VCR 4.0.0

--- a/lib/ghtorrent/adapters/base_adapter.rb
+++ b/lib/ghtorrent/adapters/base_adapter.rb
@@ -80,6 +80,10 @@ module GHTorrent
       end
     end
 
+    def check_entity_exists(entity)
+      raise "Persister: Entity #{entity} not known" unless bsearch(ENTITIES, entity)
+    end
+
     # Get a raw connection to the underlying data store. The connection is
     # implementaiton dependent.
     def get_underlying_connection

--- a/lib/ghtorrent/adapters/mongo_persister.rb
+++ b/lib/ghtorrent/adapters/mongo_persister.rb
@@ -2,6 +2,7 @@ require 'mongo'
 require 'ghtorrent/adapters/base_adapter'
 require 'ghtorrent/bson_orderedhash'
 
+require 'byebug'
 module GHTorrent
 
   # A persistence adapter that saves data into a configurable MongoDB database.
@@ -61,8 +62,8 @@ module GHTorrent
     end
 
     def replace(entity, query, new_entry, upsert = true)
-      super upsert(entity)
-      r = mongo[entity].replace_one(query, new_entry, upsert) 
+      check_entity_exists(entity)		
+      r = mongo[entity].replace_one(query, new_entry, {:upsert => upsert}) 
       r
     end
 

--- a/lib/ghtorrent/adapters/mongo_persister.rb
+++ b/lib/ghtorrent/adapters/mongo_persister.rb
@@ -60,6 +60,12 @@ module GHTorrent
       mongo[entity].insert_one(data).to_s
     end
 
+    def replace(entity, query, new_entry, upsert = true)
+      super upsert(entity)
+      r = mongo[entity].replace_one(query, new_entry, upsert) 
+      r
+    end
+
     def find(entity, query = {})
       super
       mongo[entity].

--- a/lib/ghtorrent/adapters/mongo_persister.rb
+++ b/lib/ghtorrent/adapters/mongo_persister.rb
@@ -2,7 +2,6 @@ require 'mongo'
 require 'ghtorrent/adapters/base_adapter'
 require 'ghtorrent/bson_orderedhash'
 
-require 'byebug'
 module GHTorrent
 
   # A persistence adapter that saves data into a configurable MongoDB database.

--- a/lib/ghtorrent/adapters/mongo_persister.rb
+++ b/lib/ghtorrent/adapters/mongo_persister.rb
@@ -63,7 +63,7 @@ module GHTorrent
 
     def replace(entity, query, new_entry, upsert = true)
       check_entity_exists(entity)		
-      r = mongo[entity].replace_one(query, new_entry, {:upsert => upsert}) 
+      r = mongo[entity].update_one(query, new_entry, {:upsert => upsert}) 
       r
     end
 

--- a/lib/ghtorrent/commands/full_repo_retriever.rb
+++ b/lib/ghtorrent/commands/full_repo_retriever.rb
@@ -27,6 +27,10 @@ module GHTorrent
         @ghtorrent
       end
 
+      def db
+        ght.db
+      end
+
       def persister
         ght.persister
       end

--- a/lib/ghtorrent/commands/full_user_retriever.rb
+++ b/lib/ghtorrent/commands/full_user_retriever.rb
@@ -18,6 +18,10 @@ module GHTorrent
         @ghtorrent
       end
 
+      def db
+        ght.db
+      end
+
       def update_persister(login, new_user)
         r = persister.del(:users, {'login' => login})
         persister.store(:users, new_user)

--- a/lib/ghtorrent/commands/full_user_retriever.rb
+++ b/lib/ghtorrent/commands/full_user_retriever.rb
@@ -33,14 +33,14 @@ module GHTorrent
         debug "User #{login} update started"
         user_entry = ght.transaction { ght.ensure_user(login, false, false) }
         on_github = api_request(ghurl ("users/#{login}"))
-
+        
         if on_github.empty?
           if user_entry.nil?
             warn "User #{login} does not exist on GitHub"
             return
           else
             ght.transaction do
-              ght.db.from(:users).where(:login => login).update(Sequel.qualify('users', 'deleted') => true)
+              ght.db.from(:users).where(:login => login).update(deleted: true)
             end
             warn "User #{login} marked as deleted"
             return
@@ -62,20 +62,20 @@ module GHTorrent
 
         ght.db.from(:users).where(:login => login).update(
             # Geolocation info
-            Sequel.qualify('users', 'long')         => geo['long'].to_f,
-            Sequel.qualify('users', 'lat')          => geo['lat'].to_f,
-            Sequel.qualify('users', 'country_code') => geo['country_code'],
-            Sequel.qualify('users', 'state')        => geo['state'],
-            Sequel.qualify('users', 'city')         => geo['city'],
-            Sequel.qualify('users', 'location')     => on_github['location'],
+            long: geo['long'].to_f,
+            lat: geo['lat'].to_f,
+            country_code: geo['country_code'],
+            state: geo['state'],
+            city: geo['city'],
+            location: on_github['location'],
 
             # user details
-            Sequel.qualify('users', 'name')    => on_github['name'],
-            Sequel.qualify('users', 'company') => on_github['company'],
-            Sequel.qualify('users', 'email')   => on_github['email'],
-            Sequel.qualify('users', 'deleted') => false,
-            Sequel.qualify('users', 'fake')    => false,
-            Sequel.qualify('users', 'type')    => user_type(on_github['type'])
+            name: on_github['name'],
+            company: on_github['company'],
+            email: on_github['email'],
+            deleted: false,
+            fake: false,
+            type: user_type(on_github['type'])
         )
 
         user = user_entry[:login]

--- a/lib/ghtorrent/commands/ght_data_retrieval.rb
+++ b/lib/ghtorrent/commands/ght_data_retrieval.rb
@@ -39,6 +39,10 @@ If event_id is provided, only this event is processed.
     @gh
   end
 
+  def db
+    ght.db
+  end
+
   def logger
     ght.logger
   end

--- a/lib/ghtorrent/commands/ght_data_retrieval.rb
+++ b/lib/ghtorrent/commands/ght_data_retrieval.rb
@@ -53,6 +53,7 @@ If event_id is provided, only this event is processed.
 
   def retrieve_event(evt_id)
     event = persister.find(:events, {'id' => evt_id}).first
+    return unless event
     event.delete '_id'
     data = JSON.parse(event.to_json)
     debug "Processing event: #{data['type']}-#{data['id']}"
@@ -98,10 +99,16 @@ If event_id is provided, only this event is processed.
         start = Time.now
         begin
           data = retrieve_event(msg)
-          send(h, data)
+          
+          if data
+            send(h, data)
 
-          channel.acknowledge(headers.delivery_tag, false)
-          info "Success processing event. Type: #{data['type']}, ID: #{data['id']}, Time: #{Time.now.to_ms - start.to_ms} ms"
+            channel.acknowledge(headers.delivery_tag, false)
+            info "Success processing event. Type: #{data['type']}, ID: #{data['id']}, Time: #{Time.now.to_ms - start.to_ms} ms"
+          else
+            channel.reject(headers.delivery_tag, false)  
+            warn "Error processing event. #{msg} not found"
+          end
         rescue StandardError => e
           # Give a message a chance to be reprocessed
           if headers.redelivered?

--- a/lib/ghtorrent/commands/ght_mirror_events.rb
+++ b/lib/ghtorrent/commands/ght_mirror_events.rb
@@ -39,6 +39,10 @@ are also queued, to ensure no additional information is gone missing.
     @persister ||= connect(:mongo, @settings)
     @persister
   end
+  
+  def ght
+    @ght ||= TransactedGHTorrent.new(settings)
+  end
 
   def store_count(events)
     stored = Array.new

--- a/lib/ghtorrent/commands/ght_mirror_events.rb
+++ b/lib/ghtorrent/commands/ght_mirror_events.rb
@@ -40,6 +40,14 @@ are also queued, to ensure no additional information is gone missing.
     @persister
   end
 
+  def ght
+    @ght ||= TransactedGHTorrent.new(settings)
+  end
+
+  def db
+    ght.db
+  end
+
   def store_count(events)
     stored = Array.new
     new = dupl = 0

--- a/lib/ghtorrent/commands/repo_updater.rb
+++ b/lib/ghtorrent/commands/repo_updater.rb
@@ -35,7 +35,7 @@ module GHTorrent
         where(Sequel.qualify('projects','owner_id') => Sequel.qualify('users','id')).\
         where(Sequel.qualify('users','login') => owner).\
         where(Sequel.qualify('projects','name') => repo).\
-        update(Sequel.qualify('projects','deleted') => true)
+        update(:deleted => true)
         info("Repo #{owner}/#{repo} marked as deleted")
       end
 
@@ -68,13 +68,13 @@ module GHTorrent
         where(Sequel.qualify('projects', 'owner_id') => Sequel.qualify('users','id')).\
         where(Sequel.qualify('users', 'login') => owner).\
         where(Sequel.qualify('projects', 'name') => repo).\
-        update(Sequel.qualify('projects', 'url')              => retrieved['url'],
-               Sequel.qualify('projects', 'description')      => retrieved['description'],
-               Sequel.qualify('projects', 'language')         => retrieved['language'],
-               Sequel.qualify('projects', 'created_at')       => date(retrieved['created_at']),
-               Sequel.qualify('projects', 'updated_at')       => Time.now,
-               Sequel.qualify('projects', 'forked_from')      => unless parent.nil? then parent[:id] end,
-               Sequel.qualify('projects', 'forked_commit_id') => unless fork_commit.nil? then fork_commit[:id] end)
+        update(url: retrieved['url'],
+               description: retrieved['description'],
+               language: retrieved['language'],
+               created_at: date(retrieved['created_at']),
+               updated_at: Time.now,
+               forked_from: unless parent.nil? then parent[:id] end,
+               forked_commit_id: unless fork_commit.nil? then fork_commit[:id] end)
         info("Repo #{owner}/#{repo} updated")
 
         ght.ensure_languages(owner, repo)

--- a/lib/ghtorrent/etag_helper.rb
+++ b/lib/ghtorrent/etag_helper.rb
@@ -1,0 +1,109 @@
+class GHTorrent::EtagHelper
+  def initialize(ght, url)
+    @ght = ght
+    @url = url
+  end
+
+  def request(media_type)
+    result = verify_etag_and_get_response(media_type) if first_page? && cacheable_endpoint?
+    result ||= @ght.do_request(@url, media_type)
+    store_etag_in_db(result) if cacheable_endpoint? && cacheable_page?(result.meta['link'])
+    result
+  end
+
+  private
+
+  def verify_etag_and_get_response(media_type)
+    etag_data, etag_response = etag_data_and_response(media_type)
+    return unless etag_response
+    log_etag_usage(etag_data) if etag_response.status[0] == '304'
+    # Since the current api call is for first page, do not return etag response for backloaded api.
+    etag_response if modified?(etag_response) && etag_data[:page_no] == 1
+  end
+
+  def cacheable_endpoint?
+    patterns = [%r{/user/(?:search|email)}, %r{/orgs/[^/]+/members},
+                %r{/users/[^/]+/orgs}, %r{/compare/.+\.\.\.},
+                %r{/commits/[^/]+$}, %r{/commits\?sha=}]
+    patterns.none? { |pattern| @url =~ pattern }
+  end
+
+  def etag_data_and_response(media_type)
+    etag_data = @ght.db[:etags].first(base_url: base_url)
+    return unless etag_data
+    etag_response = get_etag_response(etag_data, media_type)
+    [etag_data, etag_response]
+  end
+
+  def modified?(response)
+    response && response.status[0] == '200'
+  end
+
+  def first_page?
+    current_page_no.to_i == 1
+  end
+
+  def current_page_no
+    @current_page_no ||= extract_page_no(@url) || 1
+  end
+
+  def extract_page_no(string)
+    string.slice(/\bpage=(\d+)/, 1)
+  end
+
+  def store_etag_in_db(result)
+    params = { base_url: base_url, page_no: current_page_no,
+               etag: result.meta['etag'] }
+
+    record = @ght.db[:etags].first(base_url: base_url)
+    if record
+      @ght.db[:etags].where(base_url: base_url).update(params)
+    else
+      @ght.db[:etags].insert(params)
+    end
+  end
+
+  def cacheable_page?(link_headers)
+    front_loaded? ? first_page? : last_page?(link_headers)
+  end
+
+  # The Link header rel="last" will NOT be present on the last page.
+  def last_page?(link_headers)
+    link_headers !~ /\; rel="last"/
+  end
+
+  def base_url
+    return @base_url if @base_url
+    base_url = @url.slice(/^[^\?]+/).chomp('/')
+    param = '?state=closed' if @url =~ /state=closed/
+    @base_url = base_url + param.to_s
+  end
+
+  def get_etag_response(etag_data, media_type)
+    new_url = modify_page_in_url(etag_data[:page_no])
+    @ght.do_request(new_url, media_type, 'If-None-Match' => etag_data[:etag])
+  rescue OpenURI::HTTPError => e # 304 response raises an error.
+    response = e.io
+    raise e unless response.status.first == '304'
+    response
+  end
+
+  def front_loaded?
+    base_url =~ %r{/repos/[^/]+/[^/]+/\w+/?$} && base_url !~ %r{/stargazers/?$}
+  end
+
+  def modify_page_in_url(page_no)
+    page_regexp = /\bpage=\d*/
+    if @url.match(page_regexp)
+      @url.sub(page_regexp, "page=#{page_no}")
+    else
+      appender = @url =~ /\?/ ? '&' : '?'
+      @url + "#{appender}page=#{page_no}"
+    end
+  end
+
+  def log_etag_usage(etag_data)
+    @ght.db[:etags].where(base_url: etag_data[:base_url])
+                   .update(used_count: etag_data[:used_count] + 1)
+  end
+end

--- a/lib/ghtorrent/etag_helper.rb
+++ b/lib/ghtorrent/etag_helper.rb
@@ -1,6 +1,8 @@
+require 'byebug'
+
 class GHTorrent::EtagHelper
-  def initialize(ght, url)
-    @ght = ght
+  def initialize(command, url)
+    @ght = command.ght
     @url = url
   end
 
@@ -15,6 +17,7 @@ class GHTorrent::EtagHelper
 
   def verify_etag_and_get_response(media_type)
     etag_data, etag_response = etag_data_and_response(media_type)
+byebug
     return unless etag_response
     log_etag_usage(etag_data) if etag_response.status[0] == '304'
     # Since the current api call is for first page, do not return etag response for backloaded api.

--- a/lib/ghtorrent/etag_helper.rb
+++ b/lib/ghtorrent/etag_helper.rb
@@ -1,6 +1,3 @@
-<<<<<<< HEAD
-require 'byebug'
-
 class GHTorrent::EtagHelper
   def initialize(command, url)
     @ght = command.ght

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -32,6 +32,10 @@ module GHTorrent
       @persister.close unless @persister.nil?
     end
 
+    def ght
+      self
+    end
+
     # Get a connection to the database
     def db
       return @db unless @db.nil?

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -563,16 +563,12 @@ module GHTorrent
         warn "Could not find user #{user}"
         return
       end
-
-      currepo = repos.first(:owner_id => curuser[:id], :name => repo)
-
-      unless currepo.nil?
-        debug "Repo #{user}/#{repo} exists"
-        return currepo
-      end
-
-      r = retrieve_repo(user, repo, true)
-
+      
+      #          New functionality
+      # Always persist updated repositories.  
+      # etag functionality will be used to ensure we don't
+      # hit the repo api too often
+      r = persist_repo(user, repo)
       if r.nil?
         warn "Could not retrieve repo #{user}/#{repo}"
         return
@@ -583,6 +579,13 @@ module GHTorrent
         curuser = ensure_user(r['owner']['login'], false, false)
       end
 
+      currepo = repos.first(:owner_id => curuser[:id], :name => repo)
+
+      unless currepo.nil?
+        debug "Repo #{user}/#{repo} exists"
+        return currepo
+      end
+      
       repos.insert(:url => r['url'],
                    :owner_id => curuser[:id],
                    :name => r['name'],

--- a/lib/ghtorrent/ghtorrent.rb
+++ b/lib/ghtorrent/ghtorrent.rb
@@ -574,11 +574,6 @@ module GHTorrent
         return
       end
 
-      if r['owner']['login'] != curuser[:login]
-        info "Repo changed owner from #{curuser[:login]} to #{r['owner']['login']}"
-        curuser = ensure_user(r['owner']['login'], false, false)
-      end
-
       currepo = repos.first(:owner_id => curuser[:id], :name => repo)
 
       unless currepo.nil?
@@ -586,6 +581,11 @@ module GHTorrent
         return currepo
       end
       
+      if r['owner']['login'] != curuser[:login]
+        info "Repo changed owner from #{curuser[:login]} to #{r['owner']['login']}"
+        curuser = ensure_user(r['owner']['login'], false, false)
+      end
+
       repos.insert(:url => r['url'],
                    :owner_id => curuser[:id],
                    :name => r['name'],

--- a/lib/ghtorrent/migrations/030_add_etags.rb
+++ b/lib/ghtorrent/migrations/030_add_etags.rb
@@ -1,0 +1,19 @@
+require 'sequel'
+require 'ghtorrent/migrations/mysql_defaults'
+
+Sequel.migration do
+  up do
+    puts 'Adding table etags'
+    create_table :etags do
+      String :base_url, unique: true, null: false
+      String :etag, size: 40, null: false
+      Integer :page_no, null: false, default: 1
+      Integer :used_count, default: 0
+    end
+  end
+
+  down do
+    puts 'Dropping table etags'
+    drop_table :etags
+  end
+end

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -217,12 +217,25 @@ module GHTorrent
       end.select{|x| not x.nil?}
     end
 
+    def request_repo(user, repo)
+      url = ghurl "repos/#{user}/#{repo}"
+      r = api_request(url)
+    end
+
+    def persist_repo(user,repo)
+      byebug
+      repo = request_repo(user, repo)
+      return unless repo and !repo.empty?
+
+      persister.upsert(:repos, {'name' => repo['name'], 'owner.login' => repo['owner']['login']}, repo)
+      info "Added or updated repo #{user} -> #{repo}"
+    end
+
     def retrieve_repo(user, repo, refresh = false)
       stored_repo = persister.find(:repos, {'owner.login' => user,
                                              'name' => repo })
       if stored_repo.empty? or refresh
-        url = ghurl "repos/#{user}/#{repo}"
-        r = api_request(url)
+       r = request_repo(user, repo)
 
         if r.nil? or r.empty?
           return

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -5,7 +5,6 @@ require 'ghtorrent/api_client'
 require 'ghtorrent/settings'
 require 'ghtorrent/utils'
 require 'ghtorrent/logging'
-require 'byebug'
 
 module GHTorrent
   module Retriever

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -5,6 +5,7 @@ require 'ghtorrent/api_client'
 require 'ghtorrent/settings'
 require 'ghtorrent/utils'
 require 'ghtorrent/logging'
+require 'byebug'
 
 module GHTorrent
   module Retriever
@@ -225,9 +226,9 @@ module GHTorrent
     def persist_repo(user,repo)
       repo = request_repo(user, repo)
       return unless repo and !repo.empty?
-
       persister.replace(:repos, {'name' => repo['name'], 'owner.login' => repo['owner']['login']}, repo)
       info "Added or updated repo #{user} -> #{repo}"
+      repo	
     end
 
     def retrieve_repo(user, repo, refresh = false)

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -223,11 +223,10 @@ module GHTorrent
     end
 
     def persist_repo(user,repo)
-      byebug
       repo = request_repo(user, repo)
       return unless repo and !repo.empty?
 
-      persister.upsert(:repos, {'name' => repo['name'], 'owner.login' => repo['owner']['login']}, repo)
+      persister.replace(:repos, {'name' => repo['name'], 'owner.login' => repo['owner']['login']}, repo)
       info "Added or updated repo #{user} -> #{repo}"
     end
 

--- a/lib/ghtorrent/settings.rb
+++ b/lib/ghtorrent/settings.rb
@@ -50,11 +50,12 @@ module GHTorrent
         :amqp_exchange => 'github',
         :amqp_prefetch  => 1,
 
-        :sql_url => 'sqlite://github.db',
+        #:sql_url => 'sqlite://github.db',
         # :sql_url => 'mysql2://ghtorrent:ghtorrent@localhost/ghtorrent',
+        :sql_url => 'postgres://ght_admin:oh-Postgres!8@ght-db01.eastus.cloudapp.azure.com:5432/ght_development',       
 
         :mirror_urlbase => 'https://api.github.com/',
-        :mirror_persister => 'noop',
+        :mirror_persister => 'mongo',
         :mirror_history_pages_back => 10,
         :user_agent => 'ghtorrent',
         :store_pull_request_commits => 'false',

--- a/lib/ghtorrent/settings.rb
+++ b/lib/ghtorrent/settings.rb
@@ -55,7 +55,7 @@ module GHTorrent
         # :sql_url => 'postgres://ght_admin:oh-Postgres!8@ght-db01.eastus.cloudapp.azure.com:5432/ght_development',
 
         :mirror_urlbase => 'https://api.github.com/',
-        :mirror_persister => 'mongo',
+        :mirror_persister => 'noop',
         :mirror_history_pages_back => 10,
         :user_agent => 'ghtorrent',
         :store_pull_request_commits => 'false',

--- a/lib/ghtorrent/settings.rb
+++ b/lib/ghtorrent/settings.rb
@@ -52,9 +52,10 @@ module GHTorrent
 
         :sql_url => 'sqlite://github.db',
         # :sql_url => 'mysql2://ghtorrent:ghtorrent@localhost/ghtorrent',
+        # :sql_url => 'postgres://ght_admin:oh-Postgres!8@ght-db01.eastus.cloudapp.azure.com:5432/ght_development',
 
         :mirror_urlbase => 'https://api.github.com/',
-        :mirror_persister => 'noop',
+        :mirror_persister => 'mongo',
         :mirror_history_pages_back => 10,
         :user_agent => 'ghtorrent',
         :store_pull_request_commits => 'false',

--- a/lib/retrieve_mongo_events.rb
+++ b/lib/retrieve_mongo_events.rb
@@ -1,0 +1,103 @@
+#!/usr/bin/env ruby
+
+require 'bunny'
+require 'json'
+ 
+puts 'starting ...'
+conn = Bunny.new(:host => '40.117.209.29', :port => 5672, :username => '', :password => '')
+conn.start
+
+channel = conn.create_channel
+channel.prefetch  1
+
+exchange = channel.topic('github_temp', :durable => true,
+                         :auto_delete => false)
+
+puts "setting up queues" 
+                        
+channel.queue("repositories")
+  .bind(exchange, :routing_key => "ent.repos.#")
+  .subscribe(:manual_ack => true) do |delivery_info, properties, payload|
+    hsh = JSON.parse(payload)
+    puts "An update for Repositories: routing key is #{delivery_info.routing_key} - "\
+         "Name: #{hsh['name']} "\
+         "Forks: #{hsh['forks_count']}  "\
+         "Watchers: #{hsh['watchers_count']} "\
+         "Stargazers: #{hsh['stargazers_count']} "\
+         "Language: #{hsh['language']}"
+    channel.acknowledge(delivery_info.delivery_tag, false)
+  end
+
+channel.queue("users")
+  .bind(exchange, :routing_key => "ent.users.#")
+  .subscribe(:manual_ack => true) do |delivery_info, properties, payload|
+    puts "An update for Users: routing key is #{delivery_info.routing_key}"
+    channel.acknowledge(delivery_info.delivery_tag, false)
+  end
+
+channel.queue("commits")
+  .bind(exchange, :routing_key => "ent.commits.#")
+  .subscribe(:manual_ack => true) do |delivery_info, properties, payload|
+    puts "An update for Users: routing key is #{delivery_info.routing_key}"
+    channel.acknowledge(delivery_info.delivery_tag, false)
+  end
+
+channel.queue("orgs")
+  .bind(exchange, :routing_key => "ent.org_members.#")
+  .subscribe(:manual_ack => true) do |delivery_info, properties, payload|
+    puts "An update for Orgs: routing key is #{delivery_info.routing_key}"
+    channel.acknowledge(delivery_info.delivery_tag, false)
+  end
+
+channel.queue("forks")
+  .bind(exchange, :routing_key => "ent.forks.#")
+  .subscribe(:manual_ack => true) do |delivery_info, properties, payload|
+    puts "An update for Forks: routing key is #{delivery_info.routing_key}"
+    channel.acknowledge(delivery_info.delivery_tag, false)
+  end
+
+  channel.queue("issues")
+  .bind(exchange, :routing_key => "ent.issues.#")
+  .subscribe(:manual_ack => true) do |delivery_info, properties, payload|
+    puts "An update for Issues: routing key is #{delivery_info.routing_key}"
+    channel.acknowledge(delivery_info.delivery_tag, false)
+  end
+
+  channel.queue("pull_requests")
+  .bind(exchange, :routing_key => "ent.pull_requests.#")
+  .subscribe(:manual_ack => true) do |delivery_info, properties, payload|
+    puts "An update for Pull Requests: routing key is #{delivery_info.routing_key}"
+    channel.acknowledge(delivery_info.delivery_tag, false)
+  end
+
+  channel.queue("followers")
+  .bind(exchange, :routing_key => "ent.followers.#")
+  .subscribe(:manual_ack => true) do |delivery_info, properties, payload|
+    puts "An update for Followers: routing key is #{delivery_info.routing_key}"
+    channel.acknowledge(delivery_info.delivery_tag, false)
+  end
+
+  channel.queue("watchers")
+  .bind(exchange, :routing_key => "ent.watchers.#")
+  .subscribe(:manual_ack => true) do |delivery_info, properties, payload|
+    puts "An update for Watchers: routing key is #{delivery_info.routing_key}"
+    channel.acknowledge(delivery_info.delivery_tag, false)
+  end
+
+  stopped = false
+  while not stopped
+    begin
+      sleep(1)
+      `clear`
+    rescue Interrupt => _
+      puts 'Exit requested'
+      stopped = true
+    end
+  end
+
+  puts 'Closing AMQP connection'
+  channel.close unless channel.nil?
+  conn.close unless conn.nil?
+
+  puts "done"
+

--- a/test/helpers/assert_difference.rb
+++ b/test/helpers/assert_difference.rb
@@ -1,0 +1,11 @@
+def assert_difference(command, increment = 1)
+  current_count = eval(command)
+  yield
+  eval(command).must_equal(current_count + increment)
+end
+
+def assert_no_difference(command)
+  current_count = eval(command)
+  yield
+  eval(command).must_equal current_count
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,7 @@ require 'faker'
 require 'byebug'
 require 'helpers/shared'
 require 'helpers/minitest_trx'
+require 'helpers/assert_difference'
 require 'minitest/around/spec'
 
 FactoryGirl.find_definitions

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,3 +24,9 @@ require 'minitest/around/spec'
 
 FactoryGirl.find_definitions
 include FactoryGirl::Syntax::Methods
+
+class MiniTest::Spec
+  before do
+    GHTorrent::EtagHelper.any_instance.stubs(:cacheable_endpoint?)
+  end
+end

--- a/test/unit/api_client_test.rb
+++ b/test/unit/api_client_test.rb
@@ -2,21 +2,17 @@ require 'test_helper'
 
 class TestApiUser
   include GHTorrent::APIClient
-  
-  def ght
-    @ght ||= GHTorrent::Mirror.new(1)
-    @ght
-  end
-
-  def db
-    @db ||= ght.db
-    @db
-  end
+  attr_accessor :ght, :db
 end
 
 describe 'ApiClient' do
   let(:api_client) { TestApiUser.new }
   let(:repo_name) { 'blackducksoftware/ohcount' }
+
+  before do
+    api_client.db = db
+    api_client.ght = ght
+  end
 
   describe 'api_request' do
     it 'must fetch a github repo successfully' do

--- a/test/unit/commits_test.rb
+++ b/test/unit/commits_test.rb
@@ -30,6 +30,7 @@ describe 'GhtCommit' do
       ght.stubs(:retrieve_commit_comment).returns comment
       ght.stubs(:retrieve_commit_comments).returns commit
       ght.stubs(:retrieve_commit).returns(commit)
+      ght.stubs(:persist_repo).returns repo
 
       retval = ght.ensure_commit_comment(user.name_email, repo.name, commit.sha, comment.id)
 
@@ -134,6 +135,7 @@ describe 'GhtCommit' do
 
       ght.stubs(:retrieve_commit).returns(commit)
       ght.stubs(:retrieve_commit_comments).returns []
+      ght.stubs(:persist_repo).returns repo
       sha = commit.sha
 
       db_commit = ght.ensure_commit(repo.name, sha, user.name_email)
@@ -150,6 +152,7 @@ describe 'GhtCommit' do
                           parents: []})
 
       ght.stubs(:retrieve_commit).returns(nil)
+      ght.stubs(:persist_repo).returns repo
       sha = commit.sha
       returned_commit = ght.ensure_commit(repo.name, sha, user.name_email)
       assert returned_commit.nil?
@@ -165,6 +168,7 @@ describe 'GhtCommit' do
                           db_obj: db})
 
       ght.stubs(:retrieve_repo).returns(repo)
+      ght.stubs(:persist_repo).returns(repo)
       ght.stubs(:retrieve_commit).returns(commit)
       ght.stubs(:retrieve_commits).returns ([commit])
       sha = commit.sha
@@ -198,6 +202,7 @@ describe 'GhtCommit' do
       ght.stubs(:retrieve_commits).returns ([commit,commit2])
 
       ght.stubs(:retrieve_commit).returns(commit)
+      ght.stubs(:persist_repo).returns repo
       sha = commit.sha
 
       retval = ght.ensure_commits(user.name_email, repo.name, sha: sha,
@@ -251,6 +256,7 @@ describe 'GhtCommit' do
       commit['commit']['committer'] = user
       commit['commit']['author'].date = commit.created_at
 
+      ght.stubs(:persist_repo).returns repo
       retval = ght.store_commit(commit, repo.name, user.name_email)
 
       assert retval[:sha].must_equal commit.sha
@@ -262,7 +268,10 @@ describe 'GhtCommit' do
       # add github fields to user
       user.author = user
       user.committer = user
-      repo = create(:repo, { owner_id: user.id })
+      repo = create(:repo, :github_project, { owner_id: user.id,
+        owner: { 'login' => user.name_email },
+        db_obj: db })
+        
       commit = create(:sha, :github_commit, {project_id: repo.id, committer_id: user.id,
                       author: user,
                       committer: user,

--- a/test/unit/commits_test.rb
+++ b/test/unit/commits_test.rb
@@ -224,6 +224,7 @@ describe 'GhtCommit' do
                       parents: [] })
 
       ght.stubs(:retrieve_repo).returns(nil)
+      ght.stubs(:persist_repo).returns(repo)
 
       ght.stubs(:retrieve_commit).returns(commit)
       sha = commit.sha
@@ -273,6 +274,8 @@ describe 'GhtCommit' do
       commit['commit']['author'].date = commit.created_at
 
       ght.stubs(:retrieve_repo).returns(nil)
+      ght.stubs(:persist_repo).returns(repo)
+      
       retval = ght.store_commit(commit, repo.name, user.name_email)
 
       assert retval[:sha].must_equal commit.sha

--- a/test/unit/etag_helper_test.rb
+++ b/test/unit/etag_helper_test.rb
@@ -1,0 +1,203 @@
+require 'test_helper'
+
+class TestRetriever
+  include GHTorrent::APIClient
+  attr_accessor :db
+end
+
+EtagHelper = GHTorrent::EtagHelper
+
+describe 'EtagHelper' do
+  describe 'first_page' do
+    it 'must be truthy for the first page' do
+      ['url?per_page=2&page=',
+       'url?per_page=2&page=1',
+       'url?per_page=2&page=&var=2',
+       'url?per_page=2&page=1&var=2',
+       'url?page=&per_page=2',
+       'url?page=1&per_page=2'].each do |url|
+        EtagHelper.new(nil, url).send(:first_page?).must_equal true
+      end
+
+      ['url', 'url?per_page=1'].each do |url|
+        EtagHelper.new(nil, url).send(:first_page?).must_equal true
+      end
+    end
+
+    it 'must be false for non first pages' do
+      ['url?page=0&per_page=2',
+       'url?per_page=2&page=2',
+       'url?per_page=2&page=21',
+       'url?per_page=2&page=11&var=2'].each do |url|
+        EtagHelper.new(nil, url).send(:first_page?).must_equal false
+      end
+    end
+  end
+
+  describe 'front_loaded' do
+    it 'must be true for all repos/alphanum/alphanum/alphanum patterns except stargazers' do
+      ["https://api.github.com/repos/foo/bar/#{Faker::Lorem.word}?x=y&z=o",
+       'https://api.github.com/repos/foo/bar/comm1ts/'].each do |url|
+        EtagHelper.new(nil, url).send(:front_loaded?).must_equal true
+      end
+
+      ['https://api.github.com/repos/foo/bar/stargazers?per_page=2&page=2',
+       'https://api.github.com/repos/foo/bar/@commits',
+       'https://api.github.com/repos/foo/bar/commits/eb6ba57'].each do |url|
+        EtagHelper.new(nil, url).send(:front_loaded?).wont_equal true
+      end
+    end
+  end
+
+  describe 'request' do
+    run_tests_in_transaction
+    let(:retriever) { TestRetriever.new }
+    let(:media_type) { 'application/json' }
+
+    before do
+      retriever.db = db
+      retriever.stubs(:auth_method).returns(:none)
+    end
+
+    describe 'frontloaded apis' do
+      it 'must save the ETag for the first page' do
+        url = 'https://api.github.com/repos/blackducksoftware/ohcount/events?page=1&per_page=2'
+
+        VCR.use_cassette('github_etags_front_loaded') do
+          assert_difference 'db[:etags].count' do
+            etag_helper = EtagHelper.new(retriever, url)
+            etag_helper.request(media_type)
+          end
+        end
+      end
+
+      it 'must update existing ETag when its value is changed on Github' do
+        url = 'https://api.github.com/repos/blackducksoftware/ohcount/events?per_page=2'
+        etag = Faker::Internet.password
+        base_url = url.slice(/^[^\?]+/)
+        db[:etags].insert(base_url: base_url, etag: etag, page_no: 1)
+
+        VCR.use_cassette('github_etags_front_loaded') do
+          assert_no_difference 'db[:etags].count' do
+            etag_helper = EtagHelper.new(retriever, url)
+            etag_helper.request(media_type)
+            db[:etags].first(base_url: base_url)[:etag].wont_equal etag
+          end
+        end
+      end
+
+      it 'wont save ETag for intermediate pages' do
+        url = 'https://api.github.com/repos/blackducksoftware/ohcount/events?page=2&per_page=2'
+
+        stub_request(:get, url)
+        assert_no_difference 'db[:etags].count' do
+          etag_helper = EtagHelper.new(retriever, url)
+          etag_helper.request(media_type)
+        end
+      end
+
+      it 'must return complete response and increment etag used_count on requery' do
+        url = 'https://api.github.com/repos/blackducksoftware/ohcount/events?page=1&per_page=2'
+        etag = %(W/"c483d6f23e912a62cb1ae11316662174")
+        base_url = url.slice(/^[^\?]+/)
+        db[:etags].insert(base_url: base_url, etag: etag, page_no: 1)
+
+        VCR.use_cassette('github_etags_front_loaded_not_modified') do
+          assert_no_difference 'db[:etags].count' do
+            etag_helper = EtagHelper.new(retriever, url)
+            response = etag_helper.request(media_type)
+            response.status[0].must_equal '200'
+            JSON.parse(response.read).length.must_equal 2
+            etag_data = db[:etags].first(base_url: base_url)
+            etag_data[:etag].must_equal etag
+            etag_data[:used_count].must_equal 1
+          end
+        end
+      end
+    end
+
+    describe 'backloaded apis' do
+      it 'must save the ETag for the last page' do
+        url = 'https://api.github.com/users/linus/followers?page=43&per_page=2'
+
+        VCR.use_cassette('github_etags') do
+          assert_difference 'db[:etags].count' do
+            etag_helper = EtagHelper.new(retriever, url)
+            etag_helper.expects(:get_etag_response).never
+            etag_helper.request(media_type)
+          end
+        end
+      end
+
+      it 'must update existing ETag when its value is changed on Github' do
+        url = 'https://api.github.com/users/linus/followers?page=43&per_page=2'
+        etag = Faker::Internet.password
+        base_url = url.slice(/^[^\?]+/)
+        db[:etags].insert(base_url: base_url, etag: etag, page_no: 43)
+
+        VCR.use_cassette('github_etags') do
+          assert_no_difference 'db[:etags].count' do
+            etag_helper = EtagHelper.new(retriever, url)
+            etag_helper.request(media_type)
+            db[:etags].first(base_url: base_url)[:etag].wont_equal etag
+          end
+        end
+      end
+
+      it 'must return complete response and increment etag used_count on requery' do
+        # First request to start pagination will have no page number.
+        url = 'https://api.github.com/users/linus/followers?per_page=2'
+        etag = %(W/"7e96712c73e285b2d348146921ccc000")
+        base_url = url.slice(/^[^\?]+/)
+        db[:etags].insert(base_url: base_url, etag: etag, page_no: 44)
+
+        VCR.use_cassette('github_etags_not_modified') do
+          assert_no_difference 'db[:etags].count' do
+            etag_helper = EtagHelper.new(retriever, url)
+            response = etag_helper.request(media_type)
+            response.status[0].must_equal '200'
+            response.meta['link'].must_match /[^;]+page=2/ # asserts that this is response for first page.
+            JSON.parse(response.read).length.must_equal 2
+            etag_data = db[:etags].first(base_url: base_url)
+            etag_data[:etag].must_equal etag
+            etag_data[:used_count].must_equal 1
+          end
+        end
+      end
+    end
+
+    describe 'non cacheable endpoints' do
+      it 'wont call etag related methods' do
+        urls = %w(https://api.github.com/users/foobar/orgs
+                  https://api.github.com/repos/foo/bar/commits?sha=eb6ba57
+                  https://api.github.com/repos/foo/bar/commits/eb6ba57
+                  https://api.github.com/repos/foo/bar/compare/master...foo:develop
+                  https://api.github.com/legacy/user/email/foo
+                  https://api.github.com/legacy/user/search/foo)
+
+        retriever.stubs(:do_request).returns(stub(meta: {}))
+
+        urls.each do |url|
+          etag_helper = EtagHelper.new(retriever, url)
+          etag_helper.expects(:get_etag_response).never
+          etag_helper.expects(:store_etag_in_db).never
+          etag_helper.request(media_type)
+        end
+      end
+    end
+  end
+
+  describe 'base_url' do
+    it 'must retain the state query param only' do
+      expected_base_url = 'https://api.github.com/repos/foo/bar/pulls?state=closed'
+      url = expected_base_url + '&foobar=2'
+
+      etag_helper = EtagHelper.new(nil, url)
+      etag_helper.send(:base_url).must_equal expected_base_url
+
+      new_url = 'https://api.github.com/repos/foo/bar/pulls?foobar=n&state=closed'
+      etag_helper = EtagHelper.new(nil, new_url)
+      etag_helper.send(:base_url).must_equal expected_base_url
+    end
+  end
+end

--- a/test/unit/fork_commit_test.rb
+++ b/test/unit/fork_commit_test.rb
@@ -27,6 +27,7 @@ describe 'GhtForkCommit' do
         parents: [] })
 
       ght.stubs(:retrieve_repo).returns(repo)
+      ght.stubs(:persist_repo).returns(repo)
       ght.stubs(:retrieve_commits).returns ([commit])
 
       ght.stubs(:retrieve_commit).returns(commit)

--- a/test/unit/fork_test.rb
+++ b/test/unit/fork_test.rb
@@ -22,6 +22,7 @@ describe 'GhtFork' do
           owner: { 'login' => user.name_email },
           db_obj: db })
       ght.stubs(:retrieve_fork).returns repo
+      ght.stubs(:persist_repo).returns repo
 
       fork_owner = repo.url.split(/\//)[4]
 
@@ -62,6 +63,7 @@ describe 'GhtFork' do
           db_obj: db })
       ght.stubs(:retrieve_fork).returns repo
       ght.stubs(:retrieve_forks).returns([repo])
+      ght.stubs(:persist_repo).returns repo
 
       fork_owner = repo.url.split(/\//)[4]
 
@@ -81,6 +83,7 @@ describe 'GhtFork' do
           db_obj: db })
 
       ght.stubs(:retrieve_fork).returns repo
+      ght.stubs(:persist_repo).returns repo
       ght.stubs(:retrieve_forks).returns([repo])
 
       retval = ght.ensure_forks(user.name_email, fork_repo.name)

--- a/test/unit/issue_comment_test.rb
+++ b/test/unit/issue_comment_test.rb
@@ -29,6 +29,7 @@ describe 'GhtIssueComment' do
       ght.stubs(:retrieve_issue).returns(issue)
       ght.stubs(:retrieve_issue_comments).returns ([issue_comments])
       ght.stubs(:retrieve_issue_comment).returns issue_comments
+      ght.stubs(:persist_repo).returns repo
 
       retval = ght.ensure_issue_comments(user.name_email, repo.name,issue.issue_id)
       assert retval

--- a/test/unit/issue_event_test.rb
+++ b/test/unit/issue_event_test.rb
@@ -30,6 +30,8 @@ describe 'GhtIssueEvent' do
       ght.stubs(:retrieve_issue).returns(issue)
       ght.stubs(:retrieve_issue_events).returns ([issue_event])
       ght.stubs(:retrieve_issue_event).returns issue_event
+      ght.stubs(:persist_repo).returns repo
+
       retval = ght.ensure_issue_event(user.name_email, repo.name,
           issue.issue_id, issue_event.event_id)
       assert retval
@@ -128,6 +130,7 @@ describe 'GhtIssueEvent' do
       ght.stubs(:retrieve_issue).returns(issue)
       ght.stubs(:retrieve_issue_events).returns ([issue_event])
       ght.stubs(:retrieve_issue_event).returns issue_event
+      ght.stubs(:persist_repo).returns repo
 
       issue.pull_request = nil
 
@@ -157,6 +160,8 @@ describe 'GhtIssueEvent' do
       ght.stubs(:retrieve_issue).returns(issue)
       ght.stubs(:retrieve_issue_events).returns ([issue_event])
       ght.stubs(:retrieve_issue_event).returns issue_event
+      ght.stubs(:persist_repo).returns repo
+
       issue.pull_request = nil
       retval = ght.ensure_issue_event(user.name_email, repo.name,issue.issue_id, issue_event.event_id)
       assert retval

--- a/test/unit/issue_label_test.rb
+++ b/test/unit/issue_label_test.rb
@@ -27,6 +27,8 @@ describe 'GhtIssueLabel' do
       ght.stubs(:retrieve_issue_labels).returns ([issue_label])
       ght.stubs(:retrieve_issue_label).returns issue_label
       ght.stubs(:retrieve_repo_label).returns repo_label
+      ght.stubs(:persist_repo).returns repo
+
       ght.expects(:info)
         .returns("Added issue_label #{issue_label.name} to issue #{user.name_email}/#{repo.name} -> #{issue.issue_id}")
       retval = ght.ensure_issue_labels(user.name_email, repo.name, issue.issue_id)
@@ -61,6 +63,7 @@ describe 'GhtIssueLabel' do
       ght.stubs(:retrieve_issue_labels).returns ([issue_label])
       ght.stubs(:retrieve_issue_label).returns issue_label
       ght.stubs(:retrieve_repo_label).returns repo_label
+      ght.stubs(:persist_repo).returns repo
 
       retval = ght.ensure_issue_labels(user.name_email, repo.name, issue.issue_id)
       assert retval.empty?
@@ -128,6 +131,8 @@ describe 'GhtIssueLabel' do
       ght.stubs(:retrieve_issue_labels).returns ([issue_label])
       ght.stubs(:retrieve_issue_label).returns issue_label
       ght.stubs(:retrieve_repo_label).returns repo_label
+      ght.stubs(:persist_repo).returns repo
+
       ght.expects(:debug)
         .returns("Issue label #{issue_label.name} to issue #{user.name_email}/#{repo.name} -> #{issue_label.issue_id} exists")
         .at_least_once

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -49,6 +49,7 @@ describe 'GhtIssue' do
 
       ght.stubs(:retrieve_issues).returns([issue])
       ght.stubs(:retrieve_issue).returns(nil)
+      ght.stubs(:persist_repo).returns repo
 
       retval = ght.ensure_issues(user.name_email, repo.name)
       assert retval.empty?
@@ -80,6 +81,8 @@ describe 'GhtIssue' do
       ght.stubs(:ensure_issue_events).returns nil
       ght.stubs(:ensure_issue_comments).returns nil
       ght.stubs(:ensure_issue_labels).returns nil
+      ght.stubs(:persist_repo).returns repo
+
       retval = ght.ensure_issues(user.name_email, repo.name)
       assert retval
       assert retval[0][:id].must_equal issue.id
@@ -112,6 +115,8 @@ describe 'GhtIssue' do
       ght.stubs(:ensure_issue_events).returns nil
       ght.stubs(:ensure_issue_comments).returns nil
       ght.stubs(:ensure_issue_labels).returns nil
+      ght.stubs(:persist_repo).returns repo
+
       retval = ght.ensure_issues(user.name_email, repo.name)
       refute retval.empty?
       assert retval[0][:id].must_equal issue.id
@@ -155,6 +160,7 @@ describe 'GhtIssue' do
       ght.stubs(:ensure_issue_comments).returns nil
       ght.stubs(:ensure_issue_labels).returns nil
       ght.stubs(:ensure_user).returns user
+      ght.stubs(:persist_repo).returns repo
 
       fake_issue_id = Faker::Number.number(3).to_i
 
@@ -204,6 +210,7 @@ describe 'GhtIssue' do
       ght.stubs(:ensure_issue_labels).returns nil
       ght.stubs(:ensure_commit).returns(commit)
       ght.stubs(:retrieve_user_byemail).returns user
+      ght.stubs(:persist_repo).returns repo
 
       retval = ght.ensure_issue(user.name_email, repo.name, issue.issue_id, false, false, false)
       assert retval

--- a/test/unit/repo_label_test.rb
+++ b/test/unit/repo_label_test.rb
@@ -9,6 +9,8 @@ describe 'GHTRepoLabel' do
       repo = create(:project, :github_project, { owner_id: user.id, owner: {'login' => user.login} } )
       ght.stubs(:retrieve_repo).returns(repo)
       ght.stubs(:retrieve_repo_label).returns(nil)
+      ght.stubs(:persist_repo).returns repo
+
       ght.expects(:warn).returns("Could not retrieve repo_label #{user.name_email}/#{repo.name} -> master")
 
       retval = ght.ensure_repo_label(user.name_email, repo.name, 'master')
@@ -29,6 +31,7 @@ describe 'GHTRepoLabel' do
       user = create(:user, db_obj: db)
       repo = create(:project, :github_project, { owner_id: user.id, owner: {'login' => user.login} } )
       ght.stubs(:retrieve_repo).returns(repo)
+      ght.stubs(:persist_repo).returns repo
       ght.stubs(:retrieve_repo_label).returns(['master'])
 
       retval = ght.ensure_repo_label(user.name_email, repo.name, 'master')
@@ -40,6 +43,8 @@ describe 'GHTRepoLabel' do
       repo = create(:project, :github_project, { owner_id: user.id, owner: {'login' => user.login} } )
       ght.stubs(:ensure_user).returns user
       ght.stubs(:retrieve_repo).returns(nil)
+      ght.stubs(:persist_repo).returns nil
+
       ght.expects(:warn)
           .returns("Could not find #{user.name_email}/#{repo.name} for retrieving issue labels")
           .at_least_once
@@ -53,6 +58,7 @@ describe 'GHTRepoLabel' do
       repo = create(:project, :github_project, { owner_id: user.id, owner: {'login' => user.login} } )
 
       ght.stubs(:retrieve_repo).returns(repo)
+      ght.stubs(:persist_repo).returns repo 
       ght.stubs(:retrieve_repo_labels).returns(['master'])
       ght.stubs(:ensure_repo_label).returns('master')
 
@@ -66,6 +72,8 @@ describe 'GHTRepoLabel' do
       ght.stubs(:retrieve_user_byemail).returns(user)
       ght.stubs(:retrieve_repo).returns(nil)
       ght.stubs(:retrieve_repo_label).returns(['master'])
+      ght.stubs(:persist_repo).returns nil
+
       retval = ght.ensure_repo_label(user.name_email, repo.name, 'master')
       refute retval
     end

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -9,6 +9,7 @@ describe 'GhtRepo' do
      repo = create(:project, { owner_id: user.id, db_obj: db })
 
      assert repo.owner_id = user.id
+     ght.stubs(:persist_repo).returns repo
      repo = ght.ensure_repo(user.name_email, repo.name)
 
      assert repo
@@ -19,6 +20,7 @@ describe 'GhtRepo' do
      repo = create(:repo, {owner_id: user.id, owner: {'login' => user.login} } )
 
      ght.stubs(:retrieve_repo).returns(nil)
+     ght.stubs(:persist_repo).returns nil
      ght.expects(:warn).returns("Could not retrieve repo #{user.name_email}/#{repo.name}")
 
      repo = ght.ensure_repo(user.name_email, repo.name)
@@ -40,6 +42,7 @@ describe 'GhtRepo' do
      repo = create(:repo, {owner_id: user.id, owner: {'login' => user.login} })
 
      ght.stubs(:retrieve_repo).returns(repo)
+     ght.stubs(:persist_repo).returns repo
      ght.stubs(:ensure_fork_point).returns nil
 
      retval = ght.ensure_repo(user.name_email, repo.name)
@@ -60,6 +63,7 @@ describe 'GhtRepo' do
                    parent: {'name'  => parent_repo.name, 'owner' => {'login' =>parent_user.login}} } )
 
      ght.stubs(:retrieve_repo).returns(repo)
+     ght.stubs(:persist_repo).returns repo
 
      db_repo = ght.ensure_repo(user.name_email, repo.name)
      assert db_repo[:url].must_equal repo.url
@@ -75,6 +79,7 @@ describe 'GhtRepo' do
                    parent: {'name'  => parent_repo.name, 'owner' => {'login' =>parent_user.login}} } )
 
      ght.stubs(:retrieve_repo).returns(repo)
+     ght.stubs(:persist_repo).returns repo
      ght.stubs(:ensure_fork_point).returns nil
      db_repo = ght.ensure_repo(user.name_email, repo.name)
      assert db_repo[:url].must_equal repo.url
@@ -101,6 +106,7 @@ describe 'GhtRepo' do
       ght.stubs(:ensure_commit).returns(commit)
       ght.stubs(:retrieve_commit).returns(commit)
       ght.stubs(:retrieve_commit_comments).returns []
+      ght.stubs(:persist_repo).returns repo
       sha = commit.sha
 
       retval = ght.ensure_repo_commit(user.name_email, repo.name, sha)
@@ -117,6 +123,7 @@ describe 'GhtRepo' do
       user = create(:user, db_obj: db)
       repo = create(:project, :github_project, { owner_id: user.id, owner: {'login' => user.login} } )
       ght.stubs(:retrieve_repo).returns(repo)
+      ght.stubs(:persist_repo).returns repo
       ght.stubs(:retrieve_languages).returns({"Ruby"=>35941, "HTML"=>6085, "JavaScript"=>2239, "CSS"=>1728})
 
       ght.ensure_languages(user.name_email, repo.name)

--- a/test/unit/retriever_test.rb
+++ b/test/unit/retriever_test.rb
@@ -2,16 +2,7 @@ require 'test_helper'
 
 class TestGHTorrentRetriever
   include GHTorrent::Retriever
-
-  def ght
-    @ght ||= GHTorrent::Mirror.new(1)
-    @ght
-  end
-  
-    def db
-      @db ||= ght.db
-      @db
-    end
+  attr_accessor :ght, :db
 
   def persister
     @persister ||= ght.persister
@@ -33,8 +24,8 @@ describe GHTorrent::Retriever do
   let(:username)        { 'Priya5' }
 
   before do
-    session = 1
-    @ght = GHTorrent::Mirror.new(session)
+    retriever.db = db
+    retriever.ght = ght
   end
 
   it 'should raise error' do
@@ -169,24 +160,24 @@ describe GHTorrent::Retriever do
 
   describe 'retrieve_pull_request_commit' do
     it 'should return a pull request commit' do
-      @ght.db.transaction(rollback: :always) do
-        user = create(:user, db_obj: @ght.db)
+      db.transaction(rollback: :always) do
+        user = create(:user, db_obj: db)
         repo = create(:repo, :github_project, owner_id: user.id,
                                               owner: { 'login' => user.name_email },
-                                              db_obj: @ght.db)
+                                              db_obj: db)
 
         commit = create(:sha, :github_commit,  project_id: repo.id, committer_id: user.id,
                                                author: user,
                                                committer: user,
                                                commit:  { comment_count: 0, author: user,
                                                           committer: user },
-                                               parents: [], db_obj: @ght.db)
+                                               parents: [], db_obj: db)
         pull_request = create(:pull_request, :github_pr, base_repo_id: repo.id,
-                                                         base_commit_id: commit.id, db_obj: @ght.db)
+                                                         base_commit_id: commit.id, db_obj: db)
 
         pr_commit = create(:pull_request_commit, :github_pr_commit,
                            pull_request_id: pull_request.id, commit_id: commit.id, repo_name: repo.name,
-                           owner: user.name_email, sha: commit.sha, db_obj: @ght.db)
+                           owner: user.name_email, sha: commit.sha, db_obj: db)
         retriever.persister.stubs(:find).with(:pull_request_commits, 'sha' => pr_commit.sha).returns([pr_commit])
         retriever.retrieve_pull_request_commit(pull_request, repo, pr_commit.sha, user).must_equal pr_commit
       end
@@ -430,21 +421,22 @@ describe GHTorrent::Retriever do
         retriever.retrieve_pull_request(username, repo_name, '10').must_be_nil
       end
     end
+
     it 'should fetch pull_requests details from github and refresh the data' do
-      @ght.db.transaction(rollback: :always) do
-        user = create(:user, db_obj: @ght.db)
+      db.transaction(rollback: :always) do
+        user = create(:user, db_obj: db)
         repo = create(:repo, :github_project, owner_id: user.id,
                                               owner: { 'login' => user.name_email },
-                                              db_obj: @ght.db)
+                                              db_obj: db)
 
         commit = create(:sha, :github_commit,  project_id: repo.id, committer_id: user.id,
                                                author: user,
                                                committer: user,
                                                commit:  { comment_count: 0, author: user,
                                                           committer: user },
-                                               parents: [], db_obj: @ght.db)
+                                               parents: [], db_obj: db)
         pull_request = create(:pull_request, :github_pr, base_repo_id: repo.id,
-                                                         base_commit_id: commit.id, db_obj: @ght.db)
+                                                         base_commit_id: commit.id, db_obj: db)
         VCR.use_cassette('github_get_repo_prs') do
           retriever.persister.stubs(:find).with(:pull_requests, 'repo' => repo_name,
                                                                 'owner' => username, 'number' => pull_request.id).returns([pull_request])

--- a/test/unit/watcher_test.rb
+++ b/test/unit/watcher_test.rb
@@ -13,6 +13,7 @@ describe 'GhtWatcher' do
       # ght.stubs(:retrieve_repo).returns repo
       ght.stubs(:retrieve_watchers).returns [watcher_user]
       ght.stubs(:retrieve_watcher).returns watcher_user
+      ght.stubs(:persist_repo).returns repo
 
       retval = ght.ensure_watchers(user.name_email, repo.name)
       assert retval[0][:user_id] == watcher_user.id
@@ -27,6 +28,7 @@ describe 'GhtWatcher' do
 
       ght.stubs(:retrieve_watchers).returns [watcher_user]
       ght.stubs(:retrieve_watcher).returns watcher_user
+      ght.stubs(:persist_repo).returns repo
 
       retval = ght.ensure_watchers(user.name_email, repo.name)
       retval.first[:repo_id].must_equal repo.id
@@ -40,6 +42,7 @@ describe 'GhtWatcher' do
       repo = create(:repo, {owner_id: user.id, owner: {'login' => user.login} } )
 
       ght.stubs(:retrieve_repo).returns(nil)
+      ght.stubs(:persist_repo).returns nil
 
       retval = ght.ensure_watchers(user.name_email, repo.name)
       refute retval
@@ -54,6 +57,7 @@ describe 'GhtWatcher' do
       ght.stubs(:retrieve_watchers).returns [watcher_user]
       ght.stubs(:retrieve_watcher).returns nil
       ght.stubs(:retrieve_repo).returns(nil)
+      ght.stubs(:persist_repo).returns nil
 
       retval = ght.ensure_watcher(user.name_email, repo.name, watcher_user.name_email, DateTime.now)
       refute retval
@@ -68,6 +72,7 @@ describe 'GhtWatcher' do
       ght.stubs(:retrieve_watchers).returns [watcher_user]
       ght.stubs(:retrieve_watcher).returns nil
       ght.stubs(:retrieve_repo).returns(repo)
+      ght.stubs(:persist_repo).returns(repo)
 
       retval = ght.ensure_watcher(user.name_email, repo.name, watcher_user.name_email, DateTime.now)
       refute retval


### PR DESCRIPTION
Update Ensure_repo method to always retrieve the latest repository info from Github.  Created a new script to consume the mongo ent events.  

This branch is based on the eTag functionality that was created in the etag_preview branch.   