### PR TITLE
Configure etag for update 2 times a day

### DIFF
--- a/lib/ghtorrent/etag_helper.rb
+++ b/lib/ghtorrent/etag_helper.rb
@@ -1,5 +1,4 @@
 require_relative 'paged_etag_match_error'
-require 'byebug'
 class GHTorrent::EtagHelper
   include GHTorrent::Settings
 
@@ -24,7 +23,7 @@ class GHTorrent::EtagHelper
 
   def verify_etag_and_get_response(media_type, paged)
     etag_data, etag_response = etag_data_and_response(media_type)
-    return unless etag_response 
+    return unless etag_response
     log_etag_usage_and_raise_error(etag_data) if paged && not_modified?(etag_response)
     # For single response & frontloaded api, this value will be 1.
     # For modified backloaded api, this last page response is not useful.

--- a/lib/ghtorrent/etag_helper.rb
+++ b/lib/ghtorrent/etag_helper.rb
@@ -1,5 +1,5 @@
 require_relative 'paged_etag_match_error'
-
+require 'byebug'
 class GHTorrent::EtagHelper
   include GHTorrent::Settings
 
@@ -149,7 +149,7 @@ class GHTorrent::EtagHelper
   end
 
   def etag_valid?(etag_data)
-    hours = config(:etag_refresh_hours)
-    etag_data[:updated_at] > (DateTime.now - hours/24.0)
+    @hours ||= config(:etag_refresh_hours)
+    etag_data[:updated_at].to_datetime > (DateTime.now - @hours/24.0)
   end
 end

--- a/lib/ghtorrent/etag_helper.rb
+++ b/lib/ghtorrent/etag_helper.rb
@@ -44,7 +44,7 @@ class GHTorrent::EtagHelper
 
   def etag_data_and_response(media_type)
     etag_data = @ght.db[:etags].first(base_url: base_url) || empty_etag
-    return unless etag_data && etag_valid?(etag_data)
+    return unless etag_data && etag_recently_checked?(etag_data)
     etag_response = get_etag_response(etag_data, media_type)
     [etag_data, etag_response]
   end
@@ -147,7 +147,7 @@ class GHTorrent::EtagHelper
     end
   end
 
-  def etag_valid?(etag_data)
+  def etag_recently_checked?(etag_data)
     @hours ||= config(:etag_refresh_hours)
     etag_data[:updated_at].to_datetime > (DateTime.now - @hours/24.0)
   end

--- a/lib/ghtorrent/retriever.rb
+++ b/lib/ghtorrent/retriever.rb
@@ -226,7 +226,7 @@ module GHTorrent
       repo = request_repo(user, repo)
       return unless repo and !repo.empty?
       persister.replace(:repos, {'name' => repo['name'], 'owner.login' => repo['owner']['login']}, repo)
-      info "Added or updated repo #{user} -> #{repo}"
+      info "Added or updated repo #{user} -> #{repo['name']}"
       repo	
     end
 

--- a/lib/ghtorrent/settings.rb
+++ b/lib/ghtorrent/settings.rb
@@ -25,7 +25,7 @@ module GHTorrent
         :store_pull_request_commits => 'mirror.store_pull_request_commits',
 
         :github_token => 'mirror.token',
-
+        :etag_refresh_hours => 'mirror.etag_refresh_hours',
         :attach_ip => 'mirror.attach_ip',
 
         :rescue_loops => 'mirror.rescue_loops',
@@ -61,6 +61,7 @@ module GHTorrent
         :store_pull_request_commits => 'false',
 
         :github_token => 'place your github token here',
+        :etag_refresh_hours => 12,
 
         :attach_ip => '0.0.0.0',
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,5 +28,6 @@ include FactoryGirl::Syntax::Methods
 class MiniTest::Spec
   before do
     GHTorrent::EtagHelper.any_instance.stubs(:cacheable_endpoint?)
+    GHTorrent::EtagHelper.any_instance.stubs(:etag_valid?).returns true
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,6 @@ include FactoryGirl::Syntax::Methods
 class MiniTest::Spec
   before do
     GHTorrent::EtagHelper.any_instance.stubs(:cacheable_endpoint?)
-    GHTorrent::EtagHelper.any_instance.stubs(:etag_valid?).returns true
+    GHTorrent::EtagHelper.any_instance.stubs(:etag_recently_checked?).returns true
   end
 end

--- a/test/unit/etag_helper_test.rb
+++ b/test/unit/etag_helper_test.rb
@@ -275,14 +275,14 @@ describe 'EtagHelper' do
     end
   end
 
-  describe 'etag_valid?' do
-    before { EtagHelper.any_instance.unstub(:etag_valid?) }
-    it 'must return a static empty etag object on first run for certain endpoints' do
+  describe 'etag_recently_checked?' do
+    before { EtagHelper.any_instance.unstub(:etag_recently_checked?) }
+    it 'must return an empty response when etag has been recently checked' do
       url = 'https://api.github.com/repos/foo/bar/pulls'
       retriever = TestRetriever.new
       retriever.ght = ght
       etag_helper = EtagHelper.new(retriever, url)
-      expected_etag = { etag: EtagHelper::EMPTY_RESPONSE_ETAG, page_no: 1, updated_at: Date.today.prev_day }
+      expected_etag = { etag: EtagHelper::EMPTY_RESPONSE_ETAG, page_no: 1, updated_at: DateTime.now}
       etag_helper.expects(:get_etag_response).never
       response = etag_helper.send(:etag_data_and_response, '')
       refute response

--- a/test/unit/etag_helper_test.rb
+++ b/test/unit/etag_helper_test.rb
@@ -268,9 +268,24 @@ describe 'EtagHelper' do
       retriever = TestRetriever.new
       retriever.ght = ght
       etag_helper = EtagHelper.new(retriever, url)
-      expected_etag = { etag: EtagHelper::EMPTY_RESPONSE_ETAG, page_no: 1 }
+      expected_etag = { etag: EtagHelper::EMPTY_RESPONSE_ETAG, page_no: 1, updated_at: Date.today.prev_day }
       etag_helper.expects(:get_etag_response)
-      etag_helper.send(:etag_data_and_response, '').must_equal [expected_etag, nil]
+      response = etag_helper.send(:etag_data_and_response, '')
+      response.must_equal [expected_etag, nil]
+    end
+  end
+
+  describe 'etag_valid?' do
+    before { EtagHelper.any_instance.unstub(:etag_valid?) }
+    it 'must return a static empty etag object on first run for certain endpoints' do
+      url = 'https://api.github.com/repos/foo/bar/pulls'
+      retriever = TestRetriever.new
+      retriever.ght = ght
+      etag_helper = EtagHelper.new(retriever, url)
+      expected_etag = { etag: EtagHelper::EMPTY_RESPONSE_ETAG, page_no: 1, updated_at: Date.today.prev_day }
+      etag_helper.expects(:get_etag_response).never
+      response = etag_helper.send(:etag_data_and_response, '')
+      refute response
     end
   end
 end


### PR DESCRIPTION
Limits the number of times that an eTag call will be made.  Configurable in config.yaml by adding the following lines...

 # Number of hours between etag calls.  
  etag_refresh_hours: 12